### PR TITLE
Fix convext config so TypeScript compiles

### DIFF
--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,6 +1,5 @@
 import { defineApp } from "convex/server";
-import { DataModel } from "./_generated/dataModel";
 
-const app = defineApp<DataModel>();
+const app = defineApp();
 
 export default app;


### PR DESCRIPTION
## Summary
- remove incorrect `DataModel` generic from `convex.config.ts`

## Testing
- `npx tsc --noEmit`
- `npm run start` *(fails: Domain forbidden is not valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_6842ab786b60832399185d4b301afd8b